### PR TITLE
Add script and instructions for compliance checks

### DIFF
--- a/bin/compliance.sh
+++ b/bin/compliance.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0;0m'
+FAILED=
+AUTOLOCK_SECS=600
+SSH_KEY=~/.ssh/id_rsa
+
+function success {
+    printf "${GREEN}$@${NC}\n"
+}
+
+function fail {
+    printf "${RED}$@${NC}\n"
+    FAILED=true
+}
+
+if [[ "$(grep "Proc-Type: 4,ENCRYPTED" ${SSH_KEY})" ]]; then
+    success "SSH key is encrypted (${SSH_KEY})."
+else
+    fail "SSH key NOT encrypted: ${SSH_KEY}!!!"
+fi
+ssh_key_size="$(ssh-keygen -l -f "${SSH_KEY}" | cut -f1 -d' ')"
+if [[ "$ssh_key_size" -ge 2048 ]]; then
+    success "SSH key size 2048 bits or greater (${ssh_key_size})."
+else
+    fail "SSH key size less than 2048 bits: ${ssh_key_size}!!!"
+fi
+ssh_key_type="$(ssh-keygen -l -f "${SSH_KEY}" | cut -f4 -d' ')"
+if [[ "$ssh_key_type" == "(RSA)" ]]; then
+    success "SSH key is RSA."
+else
+    fail "SSH key isn't RSA: ${ssh_key_type}!!!"
+fi
+
+case "$(uname)" in
+    Darwin)
+        if [[ "$(fdesetup status | grep "FileVault")" == "FileVault is On." ]]; then
+            success "FileVault is on."
+        else
+            fail "FileVault not on!!! Fix: https://support.apple.com/en-gb/HT204837"
+        fi
+        if [[ "$(defaults read com.apple.screensaver askForPassword)" == "1" ]]; then
+            success "Screensaver autolock enabled."
+        else
+            fail "Screensaver autolock disabled!!!"
+        fi
+        autolock="$(defaults read com.apple.screensaver askForPasswordDelay)"
+        if [[ $autolock -le $AUTOLOCK_SECS ]]; then
+            success "Autolocks in less than ${AUTOLOCK_SECS}s (${autolock}s)."
+        else
+            fail "Autolock takes longer than ${AUTOLOCK_SECS}s (${autolock}s)!"
+        fi
+        ;;
+    *)
+        # fail "Unrecognized OS: $(uname)"
+        ;;
+esac
+
+echo "=========================="
+
+if [[ "$FAILED" ]]; then
+    echo "COMPLIANCE CHECK FAILED!!!"
+    echo "Fix above issues before pulling PHI."
+else
+    echo "Public SSH Key (${SSH_KEY}.pub):"
+    echo "$(ssh-keygen -l -f "${SSH_KEY}.pub")"
+    cat "${SSH_KEY}.pub"
+    echo "Success! Send this output to scalar@healthtensor.com"
+fi

--- a/source/checklist.md
+++ b/source/checklist.md
@@ -1,0 +1,6 @@
+# HIPAA Compliance Checklist
+
+    - [ ] Complete the annual [HealthTensor training](http://policies.healthtensor.com/training)
+    - [ ] Ensure `bin/compliance.sh` passes, report output. ([repo](https://github.com/HealthTensor/policies))
+    - [ ] Get bastion key.
+    - [ ] Create an SSH tunnel to the database.

--- a/source/training.md
+++ b/source/training.md
@@ -1103,8 +1103,18 @@ Response Team [SIRT](https://policies.healthtensor.com/#incident-response-policy
 
 # Dowloading PHI data locally
 
-The rule is very simple. You do not need access to PHI data. Do not download,
-store or open any communication containing PHI.
+Any machine which holds PHI for any time must be securely configured. Ensure
+your workstation's configuration using `bin/compliance.sh` (see
+the [repo](https://github.com/healthtensor/policies)).
+
+The `compliance.sh` script ensures that the workstation has:
+
+- Encrypted storage. ([OS X](https://support.apple.com/en-gb/HT204837), [linux](https://wiki.archlinux.org/index.php/Dm-crypt))
+- Autolock after 10 minutes of inactivity. ([OS X](https://support.apple.com/en-us/HT204379), [linux](https://www.jwz.org/xscreensaver/))
+- Password protected SSH keys.
+
+See the [system access policies](http://localhost:8888/#system-access-policy)
+for more detailed information.
 
 # Sanctions
 


### PR DESCRIPTION
## Summary

This commit adds training instructions to the training for securing a HIPAA compliant workstation. `bin/compliance.sh` checks some configurations, and reports compliance

## Test Plan

Run the compliance shell script:

```
./bin/compliance.sh
```